### PR TITLE
added fix to skip/hide symlinks in ls command

### DIFF
--- a/alcf/globus/functions/register_ls.py
+++ b/alcf/globus/functions/register_ls.py
@@ -99,6 +99,10 @@ def ls(params):
     except Exception:
         return Response(error="Unexpected error occurred during pydantic validation.").model_dump()
 
+    # Reject symlinks before resolving
+    if input_data.path.is_symlink():
+        return Response(error=f"Target path is a symlink and cannot be listed.").model_dump()
+
     # Resolve path and check if it exists
     try:
         input_data.path = input_data.path.resolve(strict=True)
@@ -229,6 +233,10 @@ def ls(params):
 
                 # Skip hidden entry if necessary
                 if not input_data.show_hidden and entry.name.startswith("."):
+                    continue
+
+                # Skip symlinks
+                if entry.is_symlink():
                     continue
 
                 # rel_path: include parent folder when recursive


### PR DESCRIPTION
- Adding is_symlink check on the original input path provided by the user
- Adding is_symlink check during the loop within a directory
Symlinks will be removed from the list of files that are returned to the user