### PR TITLE
Node count support

### DIFF
--- a/alcf/compute/alcf_adapter.py
+++ b/alcf/compute/alcf_adapter.py
@@ -115,8 +115,6 @@ class AlcfAdapter(ComputeFacilityAdapter, AlcfAuthenticatedAdapter):
         if job_spec.launcher:
             raise HTTPException(status_code=HTTP_501_NOT_IMPLEMENTED, detail="'launcher' not supported yet.")
         if job_spec.resources:
-            if job_spec.resources.node_count:
-                raise HTTPException(status_code=HTTP_501_NOT_IMPLEMENTED, detail="'node_count' not supported yet.")
             if job_spec.resources.process_count:
                 raise HTTPException(status_code=HTTP_501_NOT_IMPLEMENTED, detail="'process_count' not supported yet.")
             if job_spec.resources.processes_per_node:

--- a/alcf/compute/alcf_adapter.py
+++ b/alcf/compute/alcf_adapter.py
@@ -139,7 +139,7 @@ class AlcfAdapter(ComputeFacilityAdapter, AlcfAuthenticatedAdapter):
         graphql_url = get_graphql_url(resource.name)
 
         # Convert IRI Job spec into GraphQL Job spec
-        graphql_data = get_graphql_job_from_iri_jobspec(job_spec)
+        graphql_data = get_graphql_job_from_iri_jobspec(job_spec, resource.name)
 
         # Generate Keycloak access token for user if necessary
         if KEYCLOAK_FLAG in user.api_key:
@@ -208,7 +208,7 @@ class AlcfAdapter(ComputeFacilityAdapter, AlcfAuthenticatedAdapter):
         graphql_url = get_graphql_url(resource.name)
         
         # Convert IRI Job spec into GraphQL Job spec
-        graphql_data = get_graphql_job_from_iri_jobspec(job_spec)
+        graphql_data = get_graphql_job_from_iri_jobspec(job_spec, resource.name)
 
         # Generate Keycloak access token for user if necessary
         if KEYCLOAK_FLAG in user.api_key:

--- a/alcf/compute/graphql/converters.py
+++ b/alcf/compute/graphql/converters.py
@@ -79,6 +79,9 @@ def get_graphql_job_from_iri_jobspec(iri_jobspec: compute_models.JobSpec) -> gra
         'resourcesRequested.jobResources.wallClockTime': lambda js: js.attributes.duration if js.attributes and js.attributes.duration else None,
         'resourcesRequested.jobResources.physicalMemory': lambda js: js.resources.memory if js.resources else None,
         'resourcesRequested.jobResources.customResources': lambda js: format_custom_resources(js) if js.attributes else None,
+        'resourcesRequested.taskCount.min': lambda js: js.resources.node_count if js.resources else None,
+        'resourcesRequested.taskCount.max': lambda js: js.resources.node_count if js.resources else None,
+        'resourcesRequested.jobPlacement': lambda js: 4 if js.resources and js.resources.node_count else None,
         'queue.name': lambda js: js.attributes.queue_name if js.attributes else None,
         'accountingId': lambda js: js.attributes.account if js.attributes else None,
     }

--- a/alcf/compute/graphql/converters.py
+++ b/alcf/compute/graphql/converters.py
@@ -1,9 +1,17 @@
 from fastapi import HTTPException
 from starlette.status import (HTTP_500_INTERNAL_SERVER_ERROR)
-from app.routers.account import models as account_models
 from app.routers.compute import models as compute_models
 from alcf.compute.graphql import models as graphql_models
-from typing import Any
+from typing import Any, List
+
+
+# Job submission default values
+DEFAULT_TASK_RESOURCES_SLOTS = {
+    "polaris": 64,
+    "sirius": 64,
+    "crux": 256,
+    "edith": 1,
+}
 
 
 # Get nested value
@@ -52,21 +60,64 @@ def set_nested_value(data: dict, path: str, value: Any) -> dict:
     return data
 
 
-# Get GraphQL Job from IRI JobSpec
-def get_graphql_job_from_iri_jobspec(iri_jobspec: compute_models.JobSpec) -> graphql_models.Job:
-    """Convert an IRI JobSpec to a GraphQL Job model."""
+# Format custom resources
+def format_custom_resources(iri_jobspec: compute_models.JobSpec):
+    customResources = None
+    if iri_jobspec.attributes:
+        if iri_jobspec.attributes.custom_attributes:
+            customResources = ""
+            for name, value in iri_jobspec.attributes.custom_attributes.items():
+                customResources += '{name: "' + name + '", value: "' + value + '"}'
+    if customResources:
+        customResources = f"[{customResources}]"
+    return customResources
 
-    # Define custom resources
-    def format_custom_resources(iri_jobspec):
-        customResources = None
-        if iri_jobspec.attributes:
-            if iri_jobspec.attributes.custom_attributes:
-                customResources = ""
-                for name, value in iri_jobspec.attributes.custom_attributes.items():
-                    customResources += '{name: "' + name + '", value: "' + value + '"}'
-        if customResources:
-            customResources = f"[{customResources}]"
-        return customResources
+
+# Get node count
+def get_node_count(iri_jobspec: compute_models.JobSpec) -> int:
+    if iri_jobspec.resources and iri_jobspec.resources.node_count:
+        return iri_jobspec.resources.node_count
+    else:
+        return 1
+
+
+# Get default slots
+def get_default_slots(resource_name: str) -> int:
+    try:
+        return DEFAULT_TASK_RESOURCES_SLOTS[resource_name.lower()]
+    except Exception:
+        raise HTTPException(
+            status_code=HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Default GraphQL value for 'slots' not available for {resource_name}."
+        )
+
+
+# Format task count
+def format_task_count(iri_jobspec: compute_models.JobSpec) -> dict:
+    node_count = get_node_count(iri_jobspec)
+    return {
+        "min": node_count,
+        "max": node_count
+    }
+
+
+# Format tasks resources
+def format_tasks_resources(iri_jobspec: compute_models.JobSpec, resource_name: str) -> List[dict]:
+    node_count = get_node_count(iri_jobspec)
+    return [
+        {
+            "index": f"0-{node_count-1}" if node_count > 1 else "0",
+            "slots": get_default_slots(resource_name)
+        }
+    ]
+
+
+# Get GraphQL Job from IRI JobSpec
+def get_graphql_job_from_iri_jobspec(
+    iri_jobspec: compute_models.JobSpec,
+    resource_name: str
+) -> graphql_models.Job:
+    """Convert an IRI JobSpec to a GraphQL Job model."""
     
     # Define mapping ('graphql_job':'iri_job')
     field_mapping = {
@@ -79,9 +130,8 @@ def get_graphql_job_from_iri_jobspec(iri_jobspec: compute_models.JobSpec) -> gra
         'resourcesRequested.jobResources.wallClockTime': lambda js: js.attributes.duration if js.attributes and js.attributes.duration else None,
         'resourcesRequested.jobResources.physicalMemory': lambda js: js.resources.memory if js.resources else None,
         'resourcesRequested.jobResources.customResources': lambda js: format_custom_resources(js) if js.attributes else None,
-        'resourcesRequested.taskCount.min': lambda js: js.resources.node_count if js.resources else None,
-        'resourcesRequested.taskCount.max': lambda js: js.resources.node_count if js.resources else None,
-        'resourcesRequested.jobPlacement': lambda js: 4 if js.resources and js.resources.node_count else None,
+        'resourcesRequested.taskCount': lambda js: format_task_count(js),
+        'resourcesRequested.tasksResources': lambda js: format_tasks_resources(js, resource_name),
         'queue.name': lambda js: js.attributes.queue_name if js.attributes else None,
         'accountingId': lambda js: js.attributes.account if js.attributes else None,
     }

--- a/alcf/compute/graphql/models.py
+++ b/alcf/compute/graphql/models.py
@@ -7,6 +7,10 @@ class JobTasksResources(BaseModel):
     physicalMemory: Optional[int] = None
     customResources: Optional[str] = None
 
+class TasksResource(BaseModel):
+    index: Optional[str] = None
+    slots: Optional[int] = None
+
 class TaskCount(BaseModel):
     min: Optional[int] = None
     max: Optional[int] = None
@@ -15,7 +19,7 @@ class JobResources(BaseModel):
     peName: Optional[str] = None
     jobResources: Optional[JobTasksResources] = JobTasksResources()
     taskCount: Optional[TaskCount] = None
-    jobPlacement: Optional[int] = None
+    tasksResources: Optional[List[TasksResource]] = None
 
 class JobStatus(BaseModel):
     state: Optional[int] = None

--- a/alcf/compute/graphql/models.py
+++ b/alcf/compute/graphql/models.py
@@ -7,9 +7,15 @@ class JobTasksResources(BaseModel):
     physicalMemory: Optional[int] = None
     customResources: Optional[str] = None
 
+class TaskCount(BaseModel):
+    min: Optional[int] = None
+    max: Optional[int] = None
+
 class JobResources(BaseModel):
     peName: Optional[str] = None
     jobResources: Optional[JobTasksResources] = JobTasksResources()
+    taskCount: Optional[TaskCount] = None
+    jobPlacement: Optional[int] = None
 
 class JobStatus(BaseModel):
     state: Optional[int] = None

--- a/alcf/python_example_scripts/compute_submit_job.py
+++ b/alcf/python_example_scripts/compute_submit_job.py
@@ -32,7 +32,8 @@ data = {
     "stdout_path": "/home/bcote/qsub",
     "stderr_path": "/home/bcote/qsub",
     "resources": {
-        "memory": 2222
+        "memory": 2222,
+        "node_count": 1
     },
     "attributes": {
         "duration": 300,


### PR DESCRIPTION
Adding node_count support. This PR includes:
- functions to build GraphQL resourcesRequested.taskCount and resourcesRequested.tasksResources object
- GraphQL pydantic model adjustment to accommodate node_count
- Default values for "slots" to make sure to acquire the right number of CPUs when node_count is selected