### PR TITLE
Maintenance feature

### DIFF
--- a/alcf/account/alcf_adapter.py
+++ b/alcf/account/alcf_adapter.py
@@ -1,6 +1,8 @@
 from fastapi import HTTPException
 from app.routers.account.facility_adapter import FacilityAdapter as AccountFacilityAdapter
 from alcf.auth.alcf_adapter import AlcfAuthenticatedAdapter
+from alcf.maintenance import require_component_operational
+from alcf.enums import APIComponent
 
 # Typing
 from app.types import models as types_models
@@ -19,6 +21,7 @@ class AlcfAdapter(AccountFacilityAdapter, AlcfAuthenticatedAdapter):
     """Account facility adapter definition for the IRI Facility API."""
 
     # Get capabilities
+    @require_component_operational(APIComponent.ACCOUNT)
     async def get_capabilities(
         self: "AlcfAdapter", 
         name: str | None = None, 
@@ -30,6 +33,7 @@ class AlcfAdapter(AccountFacilityAdapter, AlcfAuthenticatedAdapter):
 
     
     # Get projects
+    @require_component_operational(APIComponent.ACCOUNT)
     async def get_projects(
         self: "AlcfAdapter", 
         user: User
@@ -38,6 +42,7 @@ class AlcfAdapter(AccountFacilityAdapter, AlcfAuthenticatedAdapter):
 
     
     # Get project allocations
+    @require_component_operational(APIComponent.ACCOUNT)
     async def get_project_allocations(
         self: "AlcfAdapter", 
         project: account_models.Project, 
@@ -47,6 +52,7 @@ class AlcfAdapter(AccountFacilityAdapter, AlcfAuthenticatedAdapter):
 
     
     # Get user allocations
+    @require_component_operational(APIComponent.ACCOUNT)
     async def get_user_allocations(
         self: "AlcfAdapter", 
         user: User, 

--- a/alcf/compute/alcf_adapter.py
+++ b/alcf/compute/alcf_adapter.py
@@ -12,6 +12,8 @@ from alcf.compute.graphql.converters import (
     get_graphql_job_from_iri_jobspec,
     get_iri_job_from_graphql_job
 )
+from alcf.maintenance import require_component_operational
+from alcf.enums import APIComponent
 
 # Typing
 from typing import List
@@ -90,6 +92,7 @@ class AlcfAdapter(ComputeFacilityAdapter, AlcfAuthenticatedAdapter):
     """Compute facility adapter definition for the IRI Facility API."""
 
     # Submit job
+    @require_component_operational(APIComponent.COMPUTE)
     @create_log_objects
     async def submit_job(
         self: "AlcfAdapter",
@@ -179,6 +182,7 @@ class AlcfAdapter(ComputeFacilityAdapter, AlcfAuthenticatedAdapter):
     
 
     # Submit job script
+    @require_component_operational(APIComponent.COMPUTE)
     @create_log_objects
     async def submit_job_script(
         self: "AlcfAdapter",
@@ -193,6 +197,7 @@ class AlcfAdapter(ComputeFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # Update job
+    @require_component_operational(APIComponent.COMPUTE)
     @create_log_objects
     async def update_job(
         self: "AlcfAdapter",
@@ -249,6 +254,7 @@ class AlcfAdapter(ComputeFacilityAdapter, AlcfAuthenticatedAdapter):
     
 
     # Get job
+    @require_component_operational(APIComponent.COMPUTE)
     @create_log_objects
     async def get_job(
         self: "AlcfAdapter",
@@ -316,6 +322,7 @@ class AlcfAdapter(ComputeFacilityAdapter, AlcfAuthenticatedAdapter):
 
     
     # Get jobs
+    @require_component_operational(APIComponent.COMPUTE)
     @create_log_objects
     async def get_jobs(
         self: "AlcfAdapter",
@@ -394,6 +401,7 @@ class AlcfAdapter(ComputeFacilityAdapter, AlcfAuthenticatedAdapter):
 
     
     # Cancel job
+    @require_component_operational(APIComponent.COMPUTE)
     @create_log_objects
     async def cancel_job(
         self: "AlcfAdapter",

--- a/alcf/compute/graphql/utils.py
+++ b/alcf/compute/graphql/utils.py
@@ -4,7 +4,8 @@ from json.decoder import JSONDecodeError
 from fastapi import HTTPException
 from app.types.user import User
 from alcf.compute.graphql import models as graphql_models
-from alcf.endpoints import get_endpoint, EndpointType, APIComponent
+from alcf.endpoints import get_endpoint
+from alcf.enums import EndpointType, APIComponent
 from alcf.config import GRAPHQL_HTTPX_TRUST_ENV
 from starlette.status import (
     HTTP_400_BAD_REQUEST, 

--- a/alcf/config.py
+++ b/alcf/config.py
@@ -7,6 +7,18 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 load_dotenv()
 
+# Maintenance
+class ComponentMaintenance(BaseSettings):
+    """Maintenance configuration."""
+
+    # Mandatory
+    component: str
+    message: str
+
+    # Prefix of environment variables
+    class Config(SettingsConfigDict):
+        env_prefix = ""
+
 
 # Database
 class DatabaseSettings(BaseSettings):
@@ -84,6 +96,7 @@ class AlcfSettings(BaseSettings):
     """Main ALCF application settings."""
 
     # Grouped variables with a prefix
+    maintenance: List[ComponentMaintenance] = Field(default_factory=[])
     database: DatabaseSettings = Field(default_factory=DatabaseSettings)
     keycloak: KeycloakSettings = Field(default_factory=KeycloakSettings)
     globus: GlobusSettings = Field(default_factory=GlobusSettings)
@@ -115,6 +128,7 @@ ALCF_ENDPOINTS = _load_endpoints()
 settings = AlcfSettings()
 
 # Assign variables
+COMPONENT_MAINTENANCE_NOTICES = settings.maintenance
 DATABASE_URL = settings.database.url
 DATABASE_SQL_ECHO = settings.database.sql_echo
 KEYCLOAK_REALM_NAME = settings.keycloak.realm_name

--- a/alcf/config.py
+++ b/alcf/config.py
@@ -1,23 +1,12 @@
 import json
 from pathlib import Path
-from typing import Optional, List
+from typing import Optional, List, Dict
 from dotenv import load_dotenv
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from alcf.enums import APIComponent
 
 load_dotenv()
-
-# Maintenance
-class ComponentMaintenance(BaseSettings):
-    """Maintenance configuration."""
-
-    # Mandatory
-    component: str
-    message: str
-
-    # Prefix of environment variables
-    class Config(SettingsConfigDict):
-        env_prefix = ""
 
 
 # Database
@@ -96,7 +85,6 @@ class AlcfSettings(BaseSettings):
     """Main ALCF application settings."""
 
     # Grouped variables with a prefix
-    maintenance: List[ComponentMaintenance] = Field(default_factory=[])
     database: DatabaseSettings = Field(default_factory=DatabaseSettings)
     keycloak: KeycloakSettings = Field(default_factory=KeycloakSettings)
     globus: GlobusSettings = Field(default_factory=GlobusSettings)
@@ -105,6 +93,7 @@ class AlcfSettings(BaseSettings):
     # Other variables without a prefix
     graphql_httpx_trust_env: bool = Field(default=True)
     authorized_idp_domain: str
+    component_maintenance_notices: Dict[APIComponent, str]
 
     # Load from .env file
     class Config(SettingsConfigDict):
@@ -128,7 +117,7 @@ ALCF_ENDPOINTS = _load_endpoints()
 settings = AlcfSettings()
 
 # Assign variables
-COMPONENT_MAINTENANCE_NOTICES = settings.maintenance
+COMPONENT_MAINTENANCE_NOTICES = settings.component_maintenance_notices
 DATABASE_URL = settings.database.url
 DATABASE_SQL_ECHO = settings.database.sql_echo
 KEYCLOAK_REALM_NAME = settings.keycloak.realm_name
@@ -147,3 +136,6 @@ REDIS_HOST = settings.redis.host
 REDIS_PORT = settings.redis.port
 GRAPHQL_HTTPX_TRUST_ENV = settings.graphql_httpx_trust_env
 AUTHORIZED_IDP_DOMAIN = settings.authorized_idp_domain
+
+print("!!!")
+print(COMPONENT_MAINTENANCE_NOTICES)

--- a/alcf/config.py
+++ b/alcf/config.py
@@ -136,6 +136,3 @@ REDIS_HOST = settings.redis.host
 REDIS_PORT = settings.redis.port
 GRAPHQL_HTTPX_TRUST_ENV = settings.graphql_httpx_trust_env
 AUTHORIZED_IDP_DOMAIN = settings.authorized_idp_domain
-
-print("!!!")
-print(COMPONENT_MAINTENANCE_NOTICES)

--- a/alcf/config.py
+++ b/alcf/config.py
@@ -93,7 +93,7 @@ class AlcfSettings(BaseSettings):
     # Other variables without a prefix
     graphql_httpx_trust_env: bool = Field(default=True)
     authorized_idp_domain: str
-    component_maintenance_notices: Dict[APIComponent, str]
+    component_maintenance_notices: Optional[Dict[APIComponent, str]] = None
 
     # Load from .env file
     class Config(SettingsConfigDict):

--- a/alcf/endpoints.py
+++ b/alcf/endpoints.py
@@ -1,29 +1,13 @@
 from typing import Generic, TypeVar
 from pydantic import BaseModel, ValidationError
 from fastapi import HTTPException
-from enum import Enum
+from alcf.enums import APIComponent, EndpointType
 from alcf.config import ALCF_ENDPOINTS
 from starlette.status import (
     HTTP_501_NOT_IMPLEMENTED,
     HTTP_404_NOT_FOUND,
     HTTP_400_BAD_REQUEST,
 )
-
-# ====================
-# Reusable definitions
-# ====================
-
-# API component enumeration
-class APIComponent(str, Enum):
-    COMPUTE = "compute"
-    FILESYSTEM = "filesystem"
-    ACCOUNT = "account"
-
-
-# Endpoint type enumeration
-class EndpointType(str, Enum):
-    PBS_GRAPHQL = "pbs_graphql"
-    GLOBUS_MULTI_USER_ENDPOINT = "globus_multi_user_endpoint"
 
 
 # Common pydantic model template for all types of endpoints

--- a/alcf/enums.py
+++ b/alcf/enums.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class APIComponent(str, Enum):
+    COMPUTE = "compute"
+    FILESYSTEM = "filesystem"
+    ACCOUNT = "account"
+
+
+class EndpointType(str, Enum):
+    PBS_GRAPHQL = "pbs_graphql"
+    GLOBUS_MULTI_USER_ENDPOINT = "globus_multi_user_endpoint"

--- a/alcf/filesystem/alcf_adapter.py
+++ b/alcf/filesystem/alcf_adapter.py
@@ -8,11 +8,14 @@ from alcf.auth.alcf_adapter import AlcfAuthenticatedAdapter
 from starlette.status import HTTP_501_NOT_IMPLEMENTED, HTTP_400_BAD_REQUEST 
 from typing import Any, Tuple
 from alcf.filesystem import validation
+from alcf.maintenance import require_component_operational
+from alcf.enums import APIComponent
 
 class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
     """Filesystem facility adapter definition for the IRI Facility API."""
 
     # Chmod
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def chmod(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -46,6 +49,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # Chown
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def chown(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -80,6 +84,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
     
 
     # Ls
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def ls(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -129,6 +134,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
           
 
     # Head
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def head(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -170,6 +176,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
     
 
     # Tail
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def tail(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -183,6 +190,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # View
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def view(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -222,6 +230,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # Checksum
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def checksum(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -232,6 +241,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # File
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def file(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -242,6 +252,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # Stat
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def stat(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -253,6 +264,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # Rm
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def rm(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -263,6 +275,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # Mkdir
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def mkdir(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -296,6 +309,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # Sumlink
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def symlink(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -306,6 +320,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # Download
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def download(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -316,6 +331,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # Upload
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def upload(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -327,6 +343,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # Compress
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def compress(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -337,6 +354,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # Extract
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def extract(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -347,6 +365,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # Mv
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def mv(
         self: "AlcfAdapter",
         resource: status_models.Resource, 
@@ -357,6 +376,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
 
 
     # Cp
+    @require_component_operational(APIComponent.FILESYSTEM)
     async def cp(
         self: "AlcfAdapter",
         resource: status_models.Resource, 

--- a/alcf/globus/utils.py
+++ b/alcf/globus/utils.py
@@ -1,5 +1,6 @@
 from cachetools import TTLCache, cached
-from alcf.endpoints import get_endpoint, EndpointType, APIComponent
+from alcf.endpoints import get_endpoint
+from alcf.enums import EndpointType, APIComponent
 from alcf.auth.utils import introspect_token as globus_introspect_token
 from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR, HTTP_400_BAD_REQUEST
 from fastapi import HTTPException

--- a/alcf/maintenance.py
+++ b/alcf/maintenance.py
@@ -13,11 +13,11 @@ def require_component_operational(component: APIComponent):
     def decorator(func):
         @wraps(func)
         async def wrapper(*args, **kwargs):            
-            for maintenance_notice in COMPONENT_MAINTENANCE_NOTICES:
-                if maintenance_notice.component == component:
+            if COMPONENT_MAINTENANCE_NOTICES:
+                if component in COMPONENT_MAINTENANCE_NOTICES:
                     raise HTTPException(
                         status_code=HTTP_503_SERVICE_UNAVAILABLE,
-                        detail=maintenance_notice.message
+                        detail=COMPONENT_MAINTENANCE_NOTICES[component]
                     )
             return await func(*args, **kwargs)
         return wrapper

--- a/alcf/maintenance.py
+++ b/alcf/maintenance.py
@@ -1,0 +1,24 @@
+from functools import wraps
+from fastapi import HTTPException
+from starlette.status import HTTP_503_SERVICE_UNAVAILABLE
+
+from alcf.config import COMPONENT_MAINTENANCE_NOTICES
+from alcf.enums import APIComponent
+
+
+def require_component_operational(component: APIComponent):
+    """
+    Raises HTTPException with 503 Service Unavailable if the component is under maintenance.
+    """
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):            
+            for maintenance_notice in COMPONENT_MAINTENANCE_NOTICES:
+                if maintenance_notice.component == component:
+                    raise HTTPException(
+                        status_code=HTTP_503_SERVICE_UNAVAILABLE,
+                        detail=maintenance_notice.message
+                    )
+            return await func(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/alcf/task/alcf_adapter.py
+++ b/alcf/task/alcf_adapter.py
@@ -7,7 +7,8 @@ from starlette.status import (
     HTTP_403_FORBIDDEN, 
     HTTP_500_INTERNAL_SERVER_ERROR
 )
-from alcf.endpoints import APIComponent, get_endpoint, EndpointType
+from alcf.endpoints import get_endpoint
+from alcf.enums import APIComponent, EndpointType
 from app.routers.task.facility_adapter import FacilityAdapter as TaskFacilityAdapter
 from app.routers.status import models as status_models
 from app.types.user import User


### PR DESCRIPTION
### Overview
Added environment variable COMPONENT_MAINTENANCE_NOTICES to easily put individual API components down for maintenance (e.g. compute, account, filesystem).

### Example
```bash
COMPONENT_MAINTENANCE_NOTICES={"filesystem": "Filesystem component down for maintenance. Expected to be back online on ...."}
```

Requests to our Filesystem component will raise a HTTP_503_SERVICE_UNAVAILABLE error with the appropriate message. But requests to other components will still work.

### Main changes
- Creation of a require_component_operational decorator
- Adding this decorator to all ALCF adaptor's routes
- Moved EndpointType and APIComponent Enum classes to enums.py to prevent circular imports