### PR TITLE
Submit job arguments

### DIFF
--- a/alcf/compute/graphql/converters.py
+++ b/alcf/compute/graphql/converters.py
@@ -140,23 +140,23 @@ def get_graphql_job_from_iri_jobspec(
     graphql_data = generate_dictionary_from_mapping(iri_jobspec, field_mapping)
 
     # Validate data
-    graphql_data = graphql_models.Job(**graphql_data)
+    graphql_job = graphql_models.Job(**graphql_data)
 
     # Format command arguments
-    graphql_data.commandArgs = format_commandArgs(graphql_data.commandArgs)
+    graphql_job = format_commandArgs(graphql_job)
     
     # Return the GraphQL Job object
-    return graphql_data
+    return graphql_job
 
 
 def format_commandArgs(
-    commandArgs: List[str] = None
-) -> List[str] | None:
+    job: graphql_models.Job
+) -> graphql_models.Job:
     """Format executable arguments commandArgs to work with GraphQL if needed."""
     
     # For each argument in the list ...
-    if commandArgs:
-        for i_arg, argument in enumerate(commandArgs):
+    if job.commandArgs and job.remoteCommand == "/bin/bash":
+        for i_arg, argument in enumerate(job.commandArgs):
 
             # Escape quotes for GraphQL
             argument = argument.replace('"', '\\"')
@@ -179,10 +179,10 @@ def format_commandArgs(
                 formatted_lines[-1] = formatted_lines[-1].rstrip(";")
 
             # Join into single line
-            commandArgs[i_arg] = " ".join(formatted_lines)
+            job.commandArgs[i_arg] = " ".join(formatted_lines)
     
     # Return formatted commandArgs
-    return commandArgs
+    return job
 
 
 # Get IRI Job from GraphQL Job

--- a/alcf/compute/graphql/converters.py
+++ b/alcf/compute/graphql/converters.py
@@ -138,9 +138,51 @@ def get_graphql_job_from_iri_jobspec(
     
     # Apply mapping
     graphql_data = generate_dictionary_from_mapping(iri_jobspec, field_mapping)
+
+    # Validate data
+    graphql_data = graphql_models.Job(**graphql_data)
+
+    # Format command arguments
+    graphql_data.commandArgs = format_commandArgs(graphql_data.commandArgs)
     
-    # Create and return the GraphQL Job object
-    return graphql_models.Job(**graphql_data)
+    # Return the GraphQL Job object
+    return graphql_data
+
+
+def format_commandArgs(
+    commandArgs: List[str] = None
+) -> List[str] | None:
+    """Format executable arguments commandArgs to work with GraphQL if needed."""
+    
+    # For each argument in the list ...
+    if commandArgs:
+        for i_arg, argument in enumerate(commandArgs):
+
+            # Escape quotes for GraphQL
+            argument = argument.replace('"', '\\"')
+
+            # Remove empty lines and strip whitespace
+            lines = [
+                line.strip()
+                for line in argument.splitlines()
+                if line.strip()
+            ]
+
+            # Add semicolons unless line ends with {
+            formatted_lines = [
+                line if line.endswith("{") else f"{line};"
+                for line in lines
+            ]
+
+            # Remove trailing semicolon from final line
+            if formatted_lines:
+                formatted_lines[-1] = formatted_lines[-1].rstrip(";")
+
+            # Join into single line
+            commandArgs[i_arg] = " ".join(formatted_lines)
+    
+    # Return formatted commandArgs
+    return commandArgs
 
 
 # Get IRI Job from GraphQL Job

--- a/alcf/python_example_scripts/compute_submit_job.py
+++ b/alcf/python_example_scripts/compute_submit_job.py
@@ -13,21 +13,15 @@ commands = """
 echo Start
 sleep 10
 echo "slept for 10 secs"
-sleep 60
 echo "using following python executable"
 which python
 echo End
 """
 
-# Convert commands into a single-line string separated with ";" and escaped quotes
-commands = commands.strip()
-commands = "; ".join(line.strip() for line in commands.splitlines() if line.strip())
-commands = commands.replace('"', '\\"')
-
 # Build input data
 data = {
     "executable": "/bin/bash",
-    "arguments": ["-c", commands],
+    "arguments": ["-lc", commands],
     "name": "TEST",
     "stdout_path": "/home/bcote/qsub",
     "stderr_path": "/home/bcote/qsub",


### PR DESCRIPTION
### Overview

Adding a formatting layer to make sure the user's input executable arguments work with GraphQL.

### Examples

With python:
```python
"executable": "/bin/bash",
"arguments": ["-lc", commands],
```

It is still working with simple `commands`
```python
commands = "echo hello"
```

But now also working with:
```python
commands = """
echo Start
sleep 10
echo "slept for 10 secs"
echo "using following python executable"
which python
echo End
"""
```

And also with this more complicated one:
```python
commands = "\nset -euo pipefail\necho \"=== IRI compute smoke test (alcf) ===\"\necho \"UTC now: $(date -u '+%Y-%m-%dT%H:%M:%SZ')\"\necho \"Hostname: $(hostname)\"\necho \"User: $(id || true)\"\necho\necho \"=== ENV (sorted) ===\"\nenv | sort\necho\necho \"=== Writing log file: /home/bcote/alcf_iri_test.log ===\"\n{\n  echo \"IRI compute smoke test log\"\n  echo \"Facility: alcf\"\n  echo \"UTC now: $(date -u '+%Y-%m-%dT%H:%M:%SZ')\"\n  echo \"Hostname: $(hostname)\"\n  echo \"---- ENV ----\"\n  env | sort\n} > \"/home/bcote/alcf_iri_test.log\"\necho \"Wrote: /home/bcote/alcf_iri_test.log\"\n"
```


