### PR TITLE
Forbid hidden files

### DIFF
--- a/alcf/filesystem/alcf_adapter.py
+++ b/alcf/filesystem/alcf_adapter.py
@@ -156,7 +156,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
         }
 
         # Validate data
-        validate_data_with_path(input_data, HeadInputData, resource.name)
+        validate_data_with_path(input_data, HeadInputData, resource.name, forbid_hidden=True)
 
         # Submit task to Globus Compute and wait for the task ID
         task_id = await globus_utils.submit_task("head", resource.name, input_data, user)
@@ -208,7 +208,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
         }
 
         # Validate data
-        validate_data_with_path(input_data, ViewInputData, resource.name)
+        validate_data_with_path(input_data, ViewInputData, resource.name, forbid_hidden=True)
 
         # Submit task to Globus Compute and wait for the task ID
         task_id = await globus_utils.submit_task("view", resource.name, input_data, user)

--- a/alcf/filesystem/validation.py
+++ b/alcf/filesystem/validation.py
@@ -206,10 +206,21 @@ def _validate_base_path(path: Path, resource_name: str):
     )
 
 
-def validate_data_with_path(input_data: dict, pydantic_class: BaseModel, resource_name: str):
+def _forbid_hidden_file(path: Path):
+    """Raise an error if the path is a hidden file."""
+    if path.name.startswith("."):
+        raise HTTPException(
+            detail="Accessing content of hidden files is forbidden.",
+            status_code=HTTP_400_BAD_REQUEST
+        )
+
+
+def validate_data_with_path(input_data: dict, pydantic_class: BaseModel, resource_name: str, forbid_hidden: bool = False):
     """Validate input parameters that include a path, and raise exception if something goes wrong."""
     try:
         validated = pydantic_class(**input_data)
         _validate_base_path(validated.path, resource_name)
+        if forbid_hidden:
+            _forbid_hidden_file(validated.path)
     except Exception as e:
         raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=f"Input validation error: {str(e)}")

--- a/alcf/filesystem/validation.py
+++ b/alcf/filesystem/validation.py
@@ -207,12 +207,13 @@ def _validate_base_path(path: Path, resource_name: str):
 
 
 def _forbid_hidden_file(path: Path):
-    """Raise an error if the path is a hidden file."""
-    if path.name.startswith("."):
-        raise HTTPException(
-            detail="Accessing content of hidden files is forbidden.",
-            status_code=HTTP_400_BAD_REQUEST
-        )
+    """Raise an error if the path is a hidden file or part of a hidden folder."""
+    for part in path.parts:
+        if part.startswith(".") and part != ".":
+            raise HTTPException(
+                detail="Accessing hidden content is forbidden.",
+                status_code=HTTP_400_BAD_REQUEST
+            )
 
 
 def validate_data_with_path(input_data: dict, pydantic_class: BaseModel, resource_name: str, forbid_hidden: bool = False):

--- a/alcf/globus/functions/register_head.py
+++ b/alcf/globus/functions/register_head.py
@@ -145,9 +145,10 @@ def head(params):
     if not input_data.path.is_file():
         return Response(error=f"Path is not a file: {input_data.path}").model_dump()
 
-    # Check if path is a hidden file
-    if input_data.path.name.startswith("."):
-        return Response(error=f"Accessing content of hidden files is forbidden. {input_data.path}.").model_dump()
+    # Check if path or any parent directory is hidden
+    for part in input_data.path.parts:
+        if part.startswith(".") and part != ".":
+            return Response(error="Accessing hidden content is forbidden.").model_dump()
 
     # Check if O_NOFOLLOW is supported (TOCTOU protection)
     o_nofollow = getattr(os, "O_NOFOLLOW", None)

--- a/alcf/globus/functions/register_head.py
+++ b/alcf/globus/functions/register_head.py
@@ -147,7 +147,7 @@ def head(params):
 
     # Check if path is a hidden file
     if input_data.path.name.startswith("."):
-        return Response(error=f"Cannot view hidden file {input_data.path}.").model_dump()
+        return Response(error=f"Accessing content of hidden files is forbidden. {input_data.path}.").model_dump()
 
     # Check if O_NOFOLLOW is supported (TOCTOU protection)
     o_nofollow = getattr(os, "O_NOFOLLOW", None)

--- a/alcf/globus/functions/register_head.py
+++ b/alcf/globus/functions/register_head.py
@@ -145,6 +145,10 @@ def head(params):
     if not input_data.path.is_file():
         return Response(error=f"Path is not a file: {input_data.path}").model_dump()
 
+    # Check if path is a hidden file
+    if input_data.path.name.startswith("."):
+        return Response(error=f"Cannot view hidden file {input_data.path}.").model_dump()
+
     # Check if O_NOFOLLOW is supported (TOCTOU protection)
     o_nofollow = getattr(os, "O_NOFOLLOW", None)
     if o_nofollow is None:

--- a/alcf/globus/functions/register_view.py
+++ b/alcf/globus/functions/register_view.py
@@ -137,7 +137,7 @@ def view(params):
 
     # Check if path is a hidden file
     if input_data.path.name.startswith("."):
-        return Response(error=f"Cannot view hidden files. {input_data.path}.").model_dump()
+        return Response(error=f"Accessing content of hidden files is forbidden. {input_data.path}.").model_dump()
 
     # Check if O_NOFOLLOW is supported (TOCTOU protection)
     o_nofollow = getattr(os, "O_NOFOLLOW", None)

--- a/alcf/globus/functions/register_view.py
+++ b/alcf/globus/functions/register_view.py
@@ -135,6 +135,10 @@ def view(params):
     if not input_data.path.is_file():
         return Response(error=f"Path {input_data.path} is not a file.").model_dump()
 
+    # Check if path is a hidden file
+    if input_data.path.name.startswith("."):
+        return Response(error=f"Cannot view hidden files. {input_data.path}.").model_dump()
+
     # Check if O_NOFOLLOW is supported (TOCTOU protection)
     o_nofollow = getattr(os, "O_NOFOLLOW", None)
     if o_nofollow is None:

--- a/alcf/globus/functions/register_view.py
+++ b/alcf/globus/functions/register_view.py
@@ -135,9 +135,10 @@ def view(params):
     if not input_data.path.is_file():
         return Response(error=f"Path {input_data.path} is not a file.").model_dump()
 
-    # Check if path is a hidden file
-    if input_data.path.name.startswith("."):
-        return Response(error=f"Accessing content of hidden files is forbidden. {input_data.path}.").model_dump()
+    # Check if path or any parent directory is hidden
+    for part in input_data.path.parts:
+        if part.startswith(".") and part != ".":
+            return Response(error="Accessing hidden content is forbidden.").model_dump()
 
     # Check if O_NOFOLLOW is supported (TOCTOU protection)
     o_nofollow = getattr(os, "O_NOFOLLOW", None)


### PR DESCRIPTION
For Filesystem operations that would expose the content of files, we are now forbidding hidden files (including those in hidden folders).