### PR TITLE
Centralizing cache

### DIFF
--- a/alcf/auth/keycloak_utils.py
+++ b/alcf/auth/keycloak_utils.py
@@ -16,6 +16,7 @@ from alcf.config import (
     KEYCLOAK_REALM_NAME,
     KEYCLOAK_PBS_GRAPHQL_AUDIENCE,
     KEYCLOAK_SERVER_URL,
+    CACHE_TTL_KEYCLOAK
 )
 from alcf.cache.manager import cache_manager
 
@@ -29,7 +30,7 @@ HEADERS = {
 
 
 # Make actual post requests to Keycloak
-@cache_manager.cached(ttl=600)
+@cache_manager.cached(ttl=CACHE_TTL_KEYCLOAK)
 def post_keycloak(payload: dict = None, url: str = None):
     """
     Do not raise exception here so that we can cache repeated errors.

--- a/alcf/auth/keycloak_utils.py
+++ b/alcf/auth/keycloak_utils.py
@@ -1,10 +1,5 @@
-import time
 import httpx
 from fastapi import HTTPException
-from alcf.cache.redis import get_redis_client
-from cachetools import TTLCache, cached
-import hashlib
-import json
 from json.decoder import JSONDecodeError
 from app.types.user import User
 from alcf.auth.utils import (
@@ -12,7 +7,6 @@ from alcf.auth.utils import (
     get_alcf_username_from_token,
 )
 from app.config import logger
-from alcf.config import AUTHORIZED_IDP_DOMAIN
 from starlette.status import (
     HTTP_401_UNAUTHORIZED,
 )
@@ -23,6 +17,7 @@ from alcf.config import (
     KEYCLOAK_PBS_GRAPHQL_AUDIENCE,
     KEYCLOAK_SERVER_URL,
 )
+from alcf.cache.manager import cache_manager
 
 # Keycloak URL to generate and exchange tokens
 KEYCLOAK_TOKEN_ENDPOINT_URL = f"{KEYCLOAK_SERVER_URL}/realms/{KEYCLOAK_REALM_NAME}/protocol/openid-connect/token"
@@ -33,56 +28,9 @@ HEADERS = {
 }
 
 
-# Post request to Keycloak (using Redis cache)
-def post_keycloak(payload: dict = None, url: str = None, ttl=60):
-    """
-    Post request to Keycloak server.
-    Uses Redis cache for multi-worker support with fallback to in-memory cache.
-    Returns serializable data.
-    """
-    
-    # Create cache key from token hash
-    # Store the entire hash to avoid collisions where different users would have the same last hash digits
-    input_str = f"{json.dumps(payload)}-{url}"
-    token_hash = hashlib.sha256(input_str.encode()).hexdigest()
-    cache_key = f"post_keycloak:{token_hash}"
-    
-    # Try to get post result from cache first
-    try:
-        redis_client = get_redis_client()
-        if redis_client:
-            cached_data = redis_client.get(cache_key)
-            if cached_data:
-                return json.loads(cached_data)
-        
-    # Fall back to in-memory cache if needed
-    except Exception as e:
-        logger.warning(f"Redis cache error for post request to Keycloak: {e}")
-        return _post_keycloak_memory_cache(payload=payload, url=url)
-
-    # Perform the token introspection if not taken from the cache
-    result = _perform_post_keycloak(payload=payload, url=url)
-    
-    # Cache the result (successful or error)
-    try:
-        redis_client = get_redis_client()
-        if redis_client:
-            redis_client.setex(cache_key, ttl, json.dumps(result))
-    except Exception as e:
-        logger.warning(f"Failed to cache post request to Keycloak: {e}")
-        # Still return the result even if caching fails
-    
-    return result
-
-
-# Post request to Keycloak (using fallback in-memory cache)
-@cached(cache=TTLCache(maxsize=1024, ttl=10))
-def _post_keycloak_memory_cache(payload: dict = None, url: str = None):
-    return _perform_post_keycloak(payload=payload, url=url)
-
-
 # Make actual post requests to Keycloak
-def _perform_post_keycloak(payload: dict = None, url: str = None):
+@cache_manager.cached(ttl=600)
+def post_keycloak(payload: dict = None, url: str = None):
     """
     Do not raise exception here so that we can cache repeated errors.
     """
@@ -122,8 +70,7 @@ def get_keycloak_impersonation_client_token():
             "client_id": KEYCLOAK_IMPERSONATION_SERVICE_CLIENT_ID,
             "client_secret": KEYCLOAK_IMPERSONATION_SERVICE_CLIENT_SECRET,
         },
-        url=KEYCLOAK_TOKEN_ENDPOINT_URL,
-        ttl=3600
+        url=KEYCLOAK_TOKEN_ENDPOINT_URL
     )
 
     # Error message
@@ -151,8 +98,7 @@ def get_impersonated_user_token(subject_token: str = None, requested_subject: st
             "requested_subject": requested_subject,
             "audience": KEYCLOAK_PBS_GRAPHQL_AUDIENCE,
         },
-        url=KEYCLOAK_TOKEN_ENDPOINT_URL,
-        ttl=600
+        url=KEYCLOAK_TOKEN_ENDPOINT_URL
     )
 
     # Error message
@@ -176,8 +122,7 @@ def introspect_token(token: str = None):
             "client_secret": KEYCLOAK_IMPERSONATION_SERVICE_CLIENT_SECRET,
             "token": token
         },
-        url=f"{KEYCLOAK_TOKEN_ENDPOINT_URL}/introspect",
-        ttl=600
+        url=f"{KEYCLOAK_TOKEN_ENDPOINT_URL}/introspect"
     )
 
     # Error message

--- a/alcf/auth/utils.py
+++ b/alcf/auth/utils.py
@@ -8,14 +8,14 @@ from alcf.config import (
     GLOBUS_GROUP,
     AUTHORIZED_IDP_DOMAIN
 )
-from alcf.cache.redis import get_redis_client
 import json
 import hashlib
 from pydantic import BaseModel, Field
 from typing import Optional, List, Tuple
 import globus_sdk
 import time
-from cachetools import TTLCache, cached
+
+from alcf.cache.manager import cache_manager
 
 # Tool to log access requests
 import logging
@@ -70,80 +70,10 @@ def get_globus_service_api_client():
     )
 
 
-# Introspect token
-def introspect_token(access_token: str):
-    """
-    Introspect a token with policies, collect group memberships, and return the response.
-    Uses Redis cache for multi-worker support with fallback to in-memory cache.
-    
-    Returns serializable data instead of Globus SDK objects.
-    """
-    
-    # Create cache key from token hash
-    # Store the entire hash to avoid collisions where different users would have the same last hash digits
-    token_hash = hashlib.sha256(access_token.encode()).hexdigest()
-    cache_key = f"token_introspect:{token_hash}"
-    
-    # Try to get introspection from cache first
-    try:
-        redis_client = get_redis_client()
-        if redis_client:
-            cached_data = redis_client.get(cache_key)
-            if cached_data:
-                return json.loads(cached_data)
-        
-    # Fall back to in-memory cache if needed
-    except Exception as e:
-        log.warning(f"Redis cache error for token introspection: {e}")
-        return _introspect_token_memory_cache(access_token)
-
-    # Perform the token introspection if not taken from the cache
-    result = _perform_token_introspection(access_token)
-
-    # Set short cache time if an error is triggered
-    if result[0] is None:
-        ttl = 60
-
-    # If the introspection was successful ...
-    else:
-
-        # Calculate time until token expiration (Unix timestamp difference)
-        try:
-            introspection_exp = result[0]["exp"]
-            seconds_until_expiration = introspection_exp - int(time.time())
-        except Exception as e:
-            log.warning(f"Failed to extract introspection result[0]['exp']: {e}")
-            seconds_until_expiration = 0
-
-        # Set cache time and make sure it is not shorter than the time until token expiration
-        ttl = min(600, seconds_until_expiration)
-    
-    # Cache the result (successful or error)
-    try:
-        redis_client = get_redis_client()
-        if redis_client:
-            redis_client.setex(cache_key, ttl, json.dumps(result))
-    except Exception as e:
-        log.warning(f"Failed to cache token introspection: {e}")
-        # Still return the result even if caching fails
-    
-    return result
-
-
-# Introspect token memory cache
-@cached(cache=TTLCache(maxsize=1024, ttl=60*10))
-def _introspect_token_memory_cache(access_token: str):
-    """
-    Fallback in-memory cache for token introspection
-    """
-    return _perform_token_introspection(access_token)
-
-
 # Perform token introspection
-def _perform_token_introspection(access_token: str):
-    """
-    Perform the actual token introspection and return serializable data.
-    """
+@cache_manager.cached(ttl=600)
+def introspect_token(access_token: str):
+    """Perform token introspection and return serializable data."""
 
     # Create Globus SDK confidential client
     try:
@@ -378,56 +308,8 @@ def validate_access_token(access_token) -> TokenValidationResponse:
     )
 
 
-# TODO: Build re-usable cache functions (issue already created on Github)
-def get_alcf_username_from_token(access_token: str, ttl: int = 600):
-    """
-    Use a token introspection response (which should be cached at this state)
-    to recover the alcf usernamne of the authenticated user.
-    Uses Redis cache for multi-worker support with fallback to in-memory cache.
-    """
-    
-    # Create cache key from token hash
-    # Store the entire hash to avoid collisions where different users would have the same last hash digits
-    token_hash = hashlib.sha256(access_token.encode()).hexdigest()
-    cache_key = f"alcf_username_:{token_hash}"
-    
-    # Try to get username from cache first
-    try:
-        redis_client = get_redis_client()
-        if redis_client:
-            cached_data = redis_client.get(cache_key)
-            if cached_data:
-                return json.loads(cached_data)
-        
-    # Fall back to in-memory cache if needed
-    except Exception as e:
-        log.warning(f"Redis cache error for alcf_username: {e}")
-        return _get_alcf_username_memory_cache(access_token)
-
-    # Perform the token introspection if not taken from the cache
-    result = _perform_get_alcf_username(access_token)
-    
-    # Cache the result
-    try:
-        redis_client = get_redis_client()
-        if redis_client:
-            redis_client.setex(cache_key, ttl, json.dumps(result))
-    except Exception as e:
-        log.warning(f"Failed to cache alcf_username: {e}")
-        # Still return the result even if caching fails
-    
-    return result
-
-
-@cached(cache=TTLCache(maxsize=1024, ttl=60*10))
-def _get_alcf_username_memory_cache(access_token: str):
-    """
-    Fallback in-memory cache for getting ALCF username from token
-    """
-    return _perform_get_alcf_username(access_token)
-
-
-def _perform_get_alcf_username(access_token: str) -> Tuple[str, str]:
+@cache_manager.cached(ttl=600)
+def get_alcf_username_from_token(access_token: str) -> Tuple[str, str]:
     """
     Use a token introspection response (which should be cached at this state)
     to recover the alcf usernamne of the authenticated user.

--- a/alcf/auth/utils.py
+++ b/alcf/auth/utils.py
@@ -6,7 +6,8 @@ from alcf.config import (
     GLOBUS_SERVICE_API_CLIENT_SECRET, 
     GLOBUS_HA_POLICY,
     GLOBUS_GROUP,
-    AUTHORIZED_IDP_DOMAIN
+    AUTHORIZED_IDP_DOMAIN,
+    CACHE_TTL_TOKEN_INTROSPECTION
 )
 import json
 import hashlib
@@ -71,7 +72,7 @@ def get_globus_service_api_client():
 
 
 # Perform token introspection
-@cache_manager.cached(ttl=600)
+@cache_manager.cached(ttl=CACHE_TTL_TOKEN_INTROSPECTION)
 def introspect_token(access_token: str):
     """Perform token introspection and return serializable data."""
 
@@ -308,7 +309,7 @@ def validate_access_token(access_token) -> TokenValidationResponse:
     )
 
 
-@cache_manager.cached(ttl=600)
+@cache_manager.cached(ttl=CACHE_TTL_TOKEN_INTROSPECTION)
 def get_alcf_username_from_token(access_token: str) -> Tuple[str, str]:
     """
     Use a token introspection response (which should be cached at this state)

--- a/alcf/cache/backends.py
+++ b/alcf/cache/backends.py
@@ -1,0 +1,67 @@
+import logging
+import time
+from abc import ABC, abstractmethod
+from typing import Optional
+from threading import RLock
+
+from alcf.cache.redis import get_redis_client
+
+log = logging.getLogger(__name__)
+
+
+class CacheBackend(ABC):
+    @abstractmethod
+    def get(self, key: str) -> Optional[str]:
+        pass
+    @abstractmethod
+    def set(self, key: str, value: str, ttl: int = 60):
+        pass
+
+
+class RedisCache(CacheBackend):
+    """Redis cache for serializable function results."""
+
+    def __init__(self):
+        self.redis = get_redis_client()
+
+    def get(self, key: str) -> Optional[str]:
+        try:
+            return self.redis.get(key)
+        except Exception as e:
+            return None
+
+    def set(self, key: str, value: str, ttl: int = 60):
+        try:
+            self.redis.set(key, value, ex=ttl)
+        except Exception as e:
+            log.warning(f"Could not cache with Redis. Key: {key}. Execption: {e}")
+            pass
+
+
+class MemoryCache(CacheBackend):
+    """Memory cache for non-serializable function results."""
+
+    def __init__(self, maxsize: int = 1024):
+        self.cache = {}
+        self.maxsize = maxsize
+        self.lock = RLock()
+
+    def get(self, key: str) -> Optional[str]:
+        with self.lock:
+            if key in self.cache:
+                value, expiry = self.cache[key]
+                if time.time() < expiry:
+                    return value
+                else:
+                    del self.cache[key]
+            return None
+
+    def set(self, key: str, value: str, ttl: int = 60):
+        with self.lock:
+            if len(self.cache) >= self.maxsize:
+                oldest_key = min(
+                    self.cache.keys(),
+                    key=lambda k: self.cache[k][1]
+                )
+                del self.cache[oldest_key]
+            self.cache[key] = (value, time.time() + ttl)

--- a/alcf/cache/backends.py
+++ b/alcf/cache/backends.py
@@ -58,10 +58,8 @@ class MemoryCache(CacheBackend):
 
     def set(self, key: str, value: str, ttl: int = 60):
         with self.lock:
-            if len(self.cache) >= self.maxsize:
-                oldest_key = min(
-                    self.cache.keys(),
-                    key=lambda k: self.cache[k][1]
-                )
-                del self.cache[oldest_key]
+            if key in self.cache: # Remove existing key so we re-insert as newest
+                del self.cache[key]
+            elif len(self.cache) >= self.maxsize:
+                self.cache.popitem(last=False) # Remove last entry if cache already full
             self.cache[key] = (value, time.time() + ttl)

--- a/alcf/cache/manager.py
+++ b/alcf/cache/manager.py
@@ -1,0 +1,126 @@
+import hashlib
+import json
+import inspect
+from typing import Callable, Any
+from functools import wraps
+
+from alcf.cache.backends import RedisCache, MemoryCache
+
+
+class CacheManager:
+    """Class to manage and streamline caching with dual options."""
+
+    def __init__(self, redis_backend=None, memory_backend=None):
+        """Initialize the two cache strategies."""
+        self.redis = redis_backend
+        self.memory = memory_backend
+
+
+    def _make_key(self, func: Callable, args: tuple, kwargs: dict) -> str:
+        """Generate unique keys based on function and its arguments."""
+
+        # Build payload from input
+        payload = {
+            "module": func.__module__,
+            "qualname": func.__qualname__,
+            "file": func.__code__.co_filename,
+            "line": func.__code__.co_firstlineno,
+            "args": args,
+            "kwargs": kwargs,
+        }
+
+        # Convert payload to a serialized string
+        serialized = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+        # Create and return hashed key from serialized string
+        return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+    def get(self, key: str):
+        """Get cached value from key."""
+
+        # Try Redis first
+        if self.redis:
+            value = self.redis.get(key)
+            if value is not None:
+                return json.loads(value)
+            
+        # Try memory cache if Redis failed
+        if self.memory:
+            value = self.memory.get(key)
+            if value is not None:
+                return value
+
+        # None if nothing cached for the given key
+        return None
+
+
+    def set(self, key: str, value: Any, ttl: int = 60):
+
+        # Try Redis first
+        if self.redis:
+            try:
+                self.redis.set(key, json.dumps(value), ttl)
+                return # Skip memory cache
+            except Exception:
+                pass # Try memory cache
+
+        # Fallback to memory if Redis failed
+        if self.memory:
+            self.memory.set(key, value, ttl)
+
+
+    def cached(self, ttl: int = 60):
+        def decorator(func: Callable):
+            """Decorator for caching async and sync functions."""
+            
+            # For asynchronous function
+            if inspect.iscoroutinefunction(func):
+                @wraps(func)
+                async def async_wrapper(*args, **kwargs):
+
+                    # Get cached value if available
+                    key = self._make_key(func, args, kwargs)
+                    cached_value = self.get(key)
+                    if cached_value is not None:
+                        return cached_value
+                    
+                    # Execute async function and wait for result
+                    result = await func(*args, **kwargs)
+
+                    # Cache and return result 
+                    self.set(key, result, ttl)
+                    return result
+                return async_wrapper
+            
+            # For synchronous function
+            else:
+                @wraps(func)
+                def sync_wrapper(*args, **kwargs):
+
+                    # Get cached value if available
+                    key = self._make_key(func, args, kwargs)
+                    cached_value = self.get(key)
+                    if cached_value is not None:
+                        return cached_value
+                    
+                    # Execute function and get result
+                    result = func(*args, **kwargs)
+
+                    # Cache and return result 
+                    self.set(key, result, ttl)
+                    return result
+                return sync_wrapper
+            
+        return decorator
+
+
+# Cache Manager
+cache_manager = CacheManager(
+    redis_backend=RedisCache(),
+    memory_backend=MemoryCache()
+)

--- a/alcf/config.py
+++ b/alcf/config.py
@@ -9,6 +9,20 @@ from alcf.enums import APIComponent
 load_dotenv()
 
 
+# Cache
+class CacheTTLSettings(BaseSettings):
+    """Cache configuration."""
+
+    # Optional
+    keycloak: Optional[int] = Field(default=600)
+    globus: Optional[int] = Field(default=600)
+    token_introspection: Optional[int] = Field(default=600)
+
+    # Prefix of environment variables
+    class Config(SettingsConfigDict):
+        env_prefix = "CACHE_TTL_"
+
+
 # Database
 class DatabaseSettings(BaseSettings):
     """Database configuration."""
@@ -85,6 +99,7 @@ class AlcfSettings(BaseSettings):
     """Main ALCF application settings."""
 
     # Grouped variables with a prefix
+    cache_ttl: CacheTTLSettings = Field(default_factory=CacheTTLSettings)
     database: DatabaseSettings = Field(default_factory=DatabaseSettings)
     keycloak: KeycloakSettings = Field(default_factory=KeycloakSettings)
     globus: GlobusSettings = Field(default_factory=GlobusSettings)
@@ -120,6 +135,9 @@ settings = AlcfSettings()
 
 # Assign variables
 COMPONENT_MAINTENANCE_NOTICES = settings.component_maintenance_notices
+CACHE_TTL_KEYCLOAK = settings.cache_ttl.keycloak
+CACHE_TTL_GLOBUS = settings.cache_ttl.globus
+CACHE_TTL_TOKEN_INTROSPECTION = settings.cache_ttl.token_introspection
 DATABASE_URL = settings.database.url
 DATABASE_SQL_ECHO = settings.database.sql_echo
 KEYCLOAK_REALM_NAME = settings.keycloak.realm_name

--- a/alcf/globus/utils.py
+++ b/alcf/globus/utils.py
@@ -1,4 +1,3 @@
-from cachetools import TTLCache, cached
 from alcf.endpoints import get_endpoint
 from alcf.enums import EndpointType, APIComponent
 from alcf.auth.utils import introspect_token as globus_introspect_token
@@ -13,8 +12,11 @@ from globus_compute_sdk.serialize import ComputeSerializer, CombinedCode
 from globus_sdk import AccessTokenAuthorizer
 ComputeScopes = ComputeScopeBuilder()
 
+from alcf.cache.manager import cache_manager
+
 
 # Get Globus Compute Executor
+@cache_manager.cached(ttl=600)
 def get_compute_executor(user_name: str, user_api_key: str) -> Executor:
     """Create a Globus Compute SDK client from user's access token"""
     try:
@@ -36,7 +38,7 @@ def get_compute_executor(user_name: str, user_api_key: str) -> Executor:
 
 
 # Get Globus Compute Client
-@cached(cache=TTLCache(maxsize=1024, ttl=60))
+@cache_manager.cached(ttl=600)
 def get_compute_client(user_name: str, user_api_key: str) -> Client:
     """Create a Globus Compute SDK client from user's access token"""
     try:

--- a/alcf/globus/utils.py
+++ b/alcf/globus/utils.py
@@ -12,11 +12,12 @@ from globus_compute_sdk.serialize import ComputeSerializer, CombinedCode
 from globus_sdk import AccessTokenAuthorizer
 ComputeScopes = ComputeScopeBuilder()
 
+from alcf.config import CACHE_TTL_GLOBUS
 from alcf.cache.manager import cache_manager
 
 
 # Get Globus Compute Executor
-@cache_manager.cached(ttl=600)
+@cache_manager.cached(ttl=CACHE_TTL_GLOBUS)
 def get_compute_executor(user_name: str, user_api_key: str) -> Executor:
     """Create a Globus Compute SDK client from user's access token"""
     try:
@@ -38,7 +39,7 @@ def get_compute_executor(user_name: str, user_api_key: str) -> Executor:
 
 
 # Get Globus Compute Client
-@cache_manager.cached(ttl=600)
+@cache_manager.cached(ttl=CACHE_TTL_GLOBUS)
 def get_compute_client(user_name: str, user_api_key: str) -> Client:
     """Create a Globus Compute SDK client from user's access token"""
     try:


### PR DESCRIPTION
### Overview
Building reusable cache manager that:
1. uses Redis whenever possible (for serializable results)
2. uses fallback in-memory cache as a backup, and as a way to cache non-serializable results (e.g. Globus client objects)

### Changes
- Caching is now done with a function decorator, which will detect whether the function is sync or async.
- Removed wrapping cache functions for "post_keycloak", "introspect_token", and "get_alcf_username"
- Reusable Redis and Memory backend file
- Reusable cache manager class with unique cache key generated from function name/location and its inputs.