### PR TITLE
Adding tests and rm command

### DIFF
--- a/alcf/filesystem/alcf_adapter.py
+++ b/alcf/filesystem/alcf_adapter.py
@@ -14,7 +14,8 @@ from alcf.filesystem.validation import (
     LsInputData,
     HeadInputData,
     ViewInputData,
-    MkdirInputData
+    MkdirInputData,
+    BaseModelWithPath,
 )
 from alcf.maintenance import require_component_operational
 from alcf.enums import APIComponent
@@ -270,8 +271,27 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
         resource: status_models.Resource, 
         user: User, 
         path: str, 
-    ):
-        raise HTTPException(status_code=HTTP_501_NOT_IMPLEMENTED, detail="Not implemented yet.")
+    ) -> str:
+        
+        # Build data for the command
+        input_data = {"path": path}
+
+        # Validate data
+        validate_data_with_path(input_data, BaseModelWithPath, resource.name)
+
+        # Submit task to Globus Compute and wait for the task ID
+        task_id = await globus_utils.submit_task("rm", resource.name, input_data, user)
+
+        # Return task ID to the user
+        return task_id
+    
+
+    # Format rm response
+    def format_rm_response(
+        self: "AlcfAdapter",
+        result
+    ) -> filesystem_models.RemoveResponse:
+        return filesystem_models.RemoveResponse(output=result)
 
 
     # Mkdir

--- a/alcf/filesystem/alcf_adapter.py
+++ b/alcf/filesystem/alcf_adapter.py
@@ -277,7 +277,7 @@ class AlcfAdapter(FilesystemFacilityAdapter, AlcfAuthenticatedAdapter):
         input_data = {"path": path}
 
         # Validate data
-        validate_data_with_path(input_data, BaseModelWithPath, resource.name)
+        validate_data_with_path(input_data, BaseModelWithPath, resource.name, forbid_hidden=True)
 
         # Submit task to Globus Compute and wait for the task ID
         task_id = await globus_utils.submit_task("rm", resource.name, input_data, user)

--- a/alcf/python_example_scripts/filesystem_rm.py
+++ b/alcf/python_example_scripts/filesystem_rm.py
@@ -1,0 +1,29 @@
+import os
+import requests
+from dotenv import load_dotenv
+load_dotenv(override=True)
+
+# Targeted resource
+resource_id = "6115bd2c-957a-4543-abff-5fae52992ff2" # Home
+#resource_id = "1c3ad9d4-2e91-42bc-becb-72b1fde1235c" # Eagle
+
+# Build input data
+data = {
+    "path": "/home/bcote/iri_dir_test"
+}
+
+# Build headers
+headers = {
+    "Authorization": f"Bearer {os.getenv('ACCESS_TOKEN', None)}",
+    "Content-Type": "application/json"
+}
+
+# Build URL
+url = f"{os.getenv('BASE_URL')}/filesystem/rm/{resource_id}"
+
+# Send request to Facility API
+response = requests.delete(url, params=data, headers=headers)
+
+# Print response
+print(response.status_code)
+print(response.json())

--- a/alcf/task/utils.py
+++ b/alcf/task/utils.py
@@ -11,7 +11,8 @@ filesystem_commands = {
     "chown": filesystem_adaptor.chown,
     "head": filesystem_adaptor.head,
     "view": filesystem_adaptor.view,
-    "mkdir": filesystem_adaptor.mkdir
+    "mkdir": filesystem_adaptor.mkdir,
+    "rm": filesystem_adaptor.rm
 }
 
 # Mapping between filesystem commands and result formating functions (needed for newly generate result)
@@ -21,7 +22,8 @@ filesystem_format_functions = {
     "chown": filesystem_adaptor.format_chown_response,
     "head": filesystem_adaptor.format_head_response,
     "view": filesystem_adaptor.format_view_response,
-    "mkdir": filesystem_adaptor.format_mkdir_response
+    "mkdir": filesystem_adaptor.format_mkdir_response,
+    "rm": filesystem_adaptor.format_rm_response
 }
 
 # Mapping between filesystem commands and response type (needed for database extraction)

--- a/alcf/tests/.env.example
+++ b/alcf/tests/.env.example
@@ -10,7 +10,7 @@ BASE_URL=http://localhost:8000/api/v1
 ACCESS_TOKEN=your_access_token_here
 
 # ── Filesystem settings ────────────────────────────────────────────────────────
-FILESYSTEM_RESOURCE_ID=6115bd2c-957a-4543-abff-5fae52992ff2
+FILESYSTEM_RESOURCE_ID=6115bd2c-957a-4543-abff-5fae52992ff2 # Home
 FILESYSTEM_BASE_PATH=/home/your_username
 
 # ── Compute settings ──────────────────────────────────────────────────────────

--- a/alcf/tests/.env.example
+++ b/alcf/tests/.env.example
@@ -1,0 +1,25 @@
+# Copy this file to .env and fill in the values
+# cp .env.example .env
+
+# API base URL (choose one)
+#BASE_URL=https://api.alcf.anl.gov/api/v1
+#BASE_URL=https://api-dev.alcf.anl.gov/api/v1
+BASE_URL=http://localhost:8000/api/v1
+
+# Globus access token
+ACCESS_TOKEN=your_access_token_here
+
+# ── Filesystem settings ────────────────────────────────────────────────────────
+FILESYSTEM_RESOURCE_ID=6115bd2c-957a-4543-abff-5fae52992ff2
+FILESYSTEM_BASE_PATH=/home/your_username
+
+# ── Compute settings ──────────────────────────────────────────────────────────
+COMPUTE_RESOURCE_ID=55c1c993-1124-47f9-b823-514ba3849a9a # Polaris
+COMPUTE_OUTPUT_PATH=/home/your_username/qsub
+COMPUTE_ACCOUNT=AmSC_Demos
+COMPUTE_QUEUE=debug
+
+# ── Task polling settings ─────────────────────────────────────────────────────
+TASK_POLL_INTERVAL=1
+TASK_TIMEOUT=120
+JOB_TIMEOUT=600

--- a/alcf/tests/requirements.txt
+++ b/alcf/tests/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31.0
+python-dotenv>=1.0.0

--- a/alcf/tests/run_all_tests.py
+++ b/alcf/tests/run_all_tests.py
@@ -1,0 +1,81 @@
+# 
+# AI generated
+#
+
+import sys
+import argparse
+import importlib
+import traceback
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+SUITES = [
+    ("filesystem", "test_filesystem"),
+    ("cancel",     "test_job_cancel"),
+    ("stdout",     "test_job_stdout"),
+]
+
+
+def run_suite(module_name: str) -> bool:
+    try:
+        mod = importlib.import_module(module_name)
+        mod.main()
+        return True
+    except SystemExit as e:
+        if e.code == 0:
+            return True
+        print(f"\n[ORCHESTRATOR] Suite '{module_name}' exited with code {e.code}")
+        return False
+    except Exception:
+        print(f"\n[ORCHESTRATOR] Suite '{module_name}' raised an exception:")
+        traceback.print_exc()
+        return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run ALCF Facility API test suites")
+    parser.add_argument("--filesystem", action="store_true", help="Run filesystem tests")
+    parser.add_argument("--cancel",     action="store_true", help="Run job cancel tests")
+    parser.add_argument("--stdout",     action="store_true", help="Run job stdout tests")
+    args = parser.parse_args()
+
+    run_all = not any([args.filesystem, args.cancel, args.stdout])
+
+    selected = [
+        (flag, mod)
+        for flag, mod in SUITES
+        if run_all or getattr(args, flag, False)
+    ]
+
+    print("\n" + "=" * 60)
+    print("  ALCF Facility API — Integration Test Runner")
+    print("=" * 60)
+    print(f"  Suites to run: {[mod for _, mod in selected]}\n")
+
+    overall_passed: list[str] = []
+    overall_failed: list[str] = []
+
+    for flag, mod in selected:
+        print(f"\n{'#' * 60}")
+        print(f"  Running suite: {mod}")
+        print(f"{'#' * 60}")
+        ok = run_suite(mod)
+        (overall_passed if ok else overall_failed).append(mod)
+
+    print(f"\n{'=' * 60}")
+    print("  OVERALL RESULT")
+    print("=" * 60)
+    for name in overall_passed:
+        print(f"  [PASS] {name}")
+    for name in overall_failed:
+        print(f"  [FAIL] {name}")
+    total = len(overall_passed) + len(overall_failed)
+    print(f"\n  {len(overall_passed)}/{total} suites passed")
+
+    if overall_failed:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/alcf/tests/test_filesystem.py
+++ b/alcf/tests/test_filesystem.py
@@ -1,0 +1,256 @@
+# 
+# AI generated
+#
+
+import sys
+import os
+import requests
+from uuid import uuid4
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+from utils import (
+    get_env,
+    get_headers,
+    get_base_url,
+    assert_status,
+    wait_for_task,
+    wait_for_job,
+    section,
+    result_summary,
+)
+
+BASE_URL = get_base_url()
+HEADERS = get_headers()
+FILESYSTEM_RESOURCE_ID = get_env("FILESYSTEM_RESOURCE_ID")
+COMPUTE_RESOURCE_ID = get_env("COMPUTE_RESOURCE_ID")
+ACCOUNT = get_env("COMPUTE_ACCOUNT")
+QUEUE = get_env("COMPUTE_QUEUE")
+BASE_PATH = get_env("FILESYSTEM_BASE_PATH").rstrip("/")
+
+TEST_DIR = f"{BASE_PATH}/alcf_test_run-{str(uuid4())[:8]}"
+TEST_SUBDIR = f"{TEST_DIR}/subdir"
+TEST_SUBDIR_FILE = f"{TEST_SUBDIR}/test.txt"
+TEST_JSON_FILE = f"{TEST_DIR}/data.json"
+TEST_TEXT_FILE = f"{TEST_DIR}/notes.txt"
+
+passed: list[str] = []
+failed: list[str] = []
+
+
+def record(name: str, ok: bool) -> None:
+    (passed if ok else failed).append(name)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def fs_url(op: str) -> str:
+    return f"{BASE_URL}/filesystem/{op}/{FILESYSTEM_RESOURCE_ID}"
+
+
+def submit_and_wait(label: str, method: str, op: str, payload: dict | None = None, params: dict | None = None, expected_status: int = 200) -> dict:
+    url = fs_url(op)
+    if method == "GET":
+        response = requests.get(url, params=params, headers=HEADERS)
+    elif method == "POST":
+        response = requests.post(url, json=payload, headers=HEADERS)
+    elif method == "PUT":
+        response = requests.put(url, json=payload, headers=HEADERS)
+    elif method == "DELETE":
+        response = requests.delete(url, params=params, headers=HEADERS)
+    else:
+        raise ValueError(f"Unsupported method: {method}")
+
+    data = assert_status(label, response, expected=expected_status)
+    task_id = data.get("task_id")
+    if not task_id:
+        print(f"  [FAIL] {label}: no task_id in response")
+        print(data)
+        sys.exit(1)
+    print(f"  [INFO] task_id = {task_id}")
+    return wait_for_task(task_id)
+
+
+# ── Test functions ─────────────────────────────────────────────────────────────
+
+def test_mkdir() -> bool:
+    section("TEST: mkdir")
+    try:
+        submit_and_wait(
+            "mkdir (create test directory)",
+            "POST",
+            "mkdir",
+            payload={"path": TEST_DIR, "parent": True},
+            expected_status=201,
+        )
+        return True
+    except SystemExit:
+        return False
+
+
+def test_populate() -> bool:
+    section("TEST: populate (submit job to create files)")
+    username = os.path.basename(BASE_PATH)
+    commands = f"""
+        mkdir -p {TEST_SUBDIR}
+        echo "Hello from the test suite" > {TEST_SUBDIR_FILE}
+        echo '{{"name": "alcf_test", "version": 1, "ok": true}}' > {TEST_JSON_FILE}
+        echo "Short note for testing." > {TEST_TEXT_FILE}
+    """
+    url = f"{BASE_URL}/compute/job/{COMPUTE_RESOURCE_ID}"
+    data = {
+        "executable": "/bin/bash",
+        "arguments": ["-lc", commands],
+        "name": "FILESYSTEM_TEST_POPULATE",
+        "stdout_path": TEST_DIR,
+        "stderr_path": TEST_DIR,
+        "resources": {
+            "node_count": 1,
+        },
+        "attributes": {
+            "duration": 300,
+            "queue_name": QUEUE,
+            "account": ACCOUNT,
+            "custom_attributes": {"filesystems": "home"},
+        },
+    }
+    try:
+        response = requests.post(url, json=data, headers=HEADERS)
+        submit_data = assert_status("Submit populate job", response, expected=200)
+        job_id = str(submit_data.get("job_id") or submit_data.get("id") or "")
+        if not job_id:
+            print(f"  [FAIL] No job_id in submit response: {submit_data}")
+            return False
+        print(f"  [INFO] Submitted job_id = {job_id}")
+        print("  [INFO] Waiting for populate job to complete...")
+        wait_for_job(COMPUTE_RESOURCE_ID, job_id)
+        return True
+    except SystemExit:
+        return False
+
+
+def test_ls_dir() -> bool:
+    section("TEST: ls (list test directory)")
+    try:
+        submit_and_wait(
+            "ls (list test directory)",
+            "GET",
+            "ls",
+            params={"path": TEST_DIR},
+        )
+        return True
+    except SystemExit:
+        return False
+
+
+def test_chmod() -> bool:
+    section("TEST: chmod")
+    try:
+        submit_and_wait(
+            "chmod (set notes.txt permissions to 644)",
+            "PUT",
+            "chmod",
+            payload={"path": TEST_TEXT_FILE, "mode": "644"},
+        )
+        submit_and_wait(
+            "chmod (set subdir permissions to 755)",
+            "PUT",
+            "chmod",
+            payload={"path": TEST_SUBDIR, "mode": "755"},
+        )
+        return True
+    except SystemExit:
+        return False
+
+
+def test_chown() -> bool:
+    section("TEST: chown")
+    username = os.path.basename(BASE_PATH)
+    try:
+        submit_and_wait(
+            "chown (set notes.txt owner)",
+            "PUT",
+            "chown",
+            payload={"path": TEST_TEXT_FILE, "owner": username, "group": "users"},
+        )
+        submit_and_wait(
+            "chown (set subdir owner)",
+            "PUT",
+            "chown",
+            payload={"path": TEST_SUBDIR, "owner": username, "group": "users"},
+        )
+        return True
+    except SystemExit:
+        return False
+
+
+def test_head() -> bool:
+    section("TEST: head")
+    try:
+        submit_and_wait(
+            "head (read first lines of notes.txt)",
+            "GET",
+            "head",
+            params={"path": TEST_TEXT_FILE, "lines": 5},
+        )
+        return True
+    except SystemExit:
+        return False
+
+
+def test_view() -> bool:
+    section("TEST: view")
+    try:
+        submit_and_wait(
+            "view (read bytes from notes.txt)",
+            "GET",
+            "view",
+            params={"path": TEST_TEXT_FILE, "size": 100, "offset": 0},
+        )
+        return True
+    except SystemExit:
+        return False
+
+
+def test_rm() -> bool:
+    section("TEST: rm")
+    try:
+        submit_and_wait(
+            "rm (remove test directory)",
+            "DELETE",
+            "rm",
+            params={"path": TEST_DIR},
+        )
+        return True
+    except SystemExit:
+        return False
+
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    print("\nFilesystem Test Suite")
+    print(f"  BASE_URL               : {BASE_URL}")
+    print(f"  FILESYSTEM_RESOURCE_ID : {FILESYSTEM_RESOURCE_ID}")
+    print(f"  COMPUTE_RESOURCE_ID    : {COMPUTE_RESOURCE_ID}")
+    print(f"  BASE_PATH              : {BASE_PATH}")
+    print(f"  TEST_DIR               : {TEST_DIR}")
+    print(f"  TEST_SUBDIR            : {TEST_SUBDIR}")
+    print(f"  TEST_TEXT_FILE         : {TEST_TEXT_FILE}")
+    print(f"  TEST_JSON_FILE         : {TEST_JSON_FILE}")
+
+    record("mkdir", test_mkdir())
+    record("populate", test_populate())
+    record("ls", test_ls_dir())
+    record("chmod", test_chmod())
+    record("chown", test_chown())
+    record("head", test_head())
+    record("view", test_view())
+    record("rm", test_rm())
+
+    result_summary(passed, failed)
+
+
+if __name__ == "__main__":
+    main()

--- a/alcf/tests/test_job_cancel.py
+++ b/alcf/tests/test_job_cancel.py
@@ -1,0 +1,129 @@
+# 
+# AI generated
+#
+
+import time
+import requests
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+from utils import (
+    get_env,
+    get_headers,
+    get_base_url,
+    assert_status,
+    wait_for_job,
+    extract_job_state,
+    section,
+    result_summary,
+    JobState,
+)
+
+BASE_URL = get_base_url()
+HEADERS = get_headers()
+RESOURCE_ID = get_env("COMPUTE_RESOURCE_ID")
+OUTPUT_PATH = get_env("COMPUTE_OUTPUT_PATH")
+ACCOUNT = get_env("COMPUTE_ACCOUNT")
+QUEUE = get_env("COMPUTE_QUEUE")
+
+passed: list[str] = []
+failed: list[str] = []
+
+
+def record(name: str, ok: bool) -> None:
+    (passed if ok else failed).append(name)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def submit_job(commands: str, name: str = "TEST_CANCEL") -> dict:
+    url = f"{BASE_URL}/compute/job/{RESOURCE_ID}"
+    data = {
+        "executable": "/bin/bash",
+        "arguments": ["-lc", commands],
+        "name": name,
+        "stdout_path": OUTPUT_PATH,
+        "stderr_path": OUTPUT_PATH,
+        "resources": {
+            "node_count": 1,
+        },
+        "attributes": {
+            "duration": 300,
+            "queue_name": QUEUE,
+            "account": ACCOUNT,
+            "custom_attributes": {"filesystems": "eagle"},
+        },
+    }
+    response = requests.post(url, json=data, headers=HEADERS)
+    return assert_status("Submit job", response, expected=200)
+
+
+def cancel_job(job_id: str) -> bool:
+    url = f"{BASE_URL}/compute/cancel/{RESOURCE_ID}/{job_id}"
+    response = requests.delete(url, headers=HEADERS)
+    if response.status_code == 204:
+        print(f"  [OK]   Cancel job {job_id} -> HTTP 204 (Cancelled)")
+        return True
+    data = assert_status(f"Cancel job {job_id}", response, expected=204)
+    return False
+
+
+def get_job_status(job_id: str, historical: bool = False) -> dict:
+    flag = "true" if historical else "false"
+    url = f"{BASE_URL}/compute/status/{RESOURCE_ID}/{job_id}?historical={flag}"
+    response = requests.get(url, headers=HEADERS)
+    return assert_status(f"Get job status {job_id}", response, expected=200)
+
+
+# ── Test ───────────────────────────────────────────────────────────────────────
+
+def test_submit_and_cancel() -> bool:
+    section("TEST: Job submission + cancellation")
+    try:
+        commands = "\necho 'Starting job'\nsleep 300\necho 'Done'\n"
+        submit_data = submit_job(commands, name="TEST_CANCEL")
+        job_id = str(submit_data.get("job_id") or submit_data.get("id") or "")
+        if not job_id:
+            print(f"  [FAIL] No job_id in submit response: {submit_data}")
+            return False
+
+        print(f"  [INFO] Waiting 5s before cancelling...")
+        time.sleep(5)
+
+        cancelled = cancel_job(job_id)
+        if not cancelled:
+            return False
+
+        print(f"  [INFO] Polling job until it reaches a terminal state...")
+        final_data = wait_for_job(RESOURCE_ID, job_id)
+        final_state = extract_job_state(final_data)
+        print(f"  [INFO] Final job state: {final_state}")
+
+        if final_state == JobState.CANCELED.value:
+            return True
+        else:
+            print(f"  [FAIL] Unexpected final state after cancel: {final_state}")
+            return False
+
+    except SystemExit:
+        return False
+
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    print("\nJob Cancel Test Suite")
+    print(f"  BASE_URL    : {BASE_URL}")
+    print(f"  RESOURCE_ID : {RESOURCE_ID}")
+    print(f"  QUEUE       : {QUEUE}")
+    print(f"  ACCOUNT     : {ACCOUNT}")
+    print(f"  OUTPUT_PATH : {OUTPUT_PATH}")
+
+    record("submit_and_cancel", test_submit_and_cancel())
+
+    result_summary(passed, failed)
+
+
+if __name__ == "__main__":
+    main()

--- a/alcf/tests/test_job_stdout.py
+++ b/alcf/tests/test_job_stdout.py
@@ -1,0 +1,164 @@
+# 
+# AI generated
+#
+
+import sys
+import requests
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+from utils import (
+    get_env,
+    get_headers,
+    get_base_url,
+    assert_status,
+    wait_for_job,
+    wait_for_task,
+    extract_job_state,
+    section,
+    result_summary,
+    JobState,
+    Task,
+)
+
+BASE_URL = get_base_url()
+HEADERS = get_headers()
+COMPUTE_RESOURCE_ID = get_env("COMPUTE_RESOURCE_ID")
+FILESYSTEM_RESOURCE_ID = get_env("FILESYSTEM_RESOURCE_ID")
+OUTPUT_PATH = get_env("COMPUTE_OUTPUT_PATH").rstrip("/")
+ACCOUNT = get_env("COMPUTE_ACCOUNT")
+QUEUE = get_env("COMPUTE_QUEUE")
+
+SENTINEL = "ALCF_TEST_STDOUT_OK_12345"
+
+passed: list[str] = []
+failed: list[str] = []
+
+
+def record(name: str, ok: bool) -> None:
+    (passed if ok else failed).append(name)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def submit_job() -> dict:
+    commands = f"""
+echo 'Job starting'
+echo '{SENTINEL}'
+echo 'Job done'
+"""
+    url = f"{BASE_URL}/compute/job/{COMPUTE_RESOURCE_ID}"
+    data = {
+        "executable": "/bin/bash",
+        "arguments": ["-lc", commands],
+        "name": "TEST_STDOUT",
+        "stdout_path": OUTPUT_PATH,
+        "stderr_path": OUTPUT_PATH,
+        "resources": {
+            "node_count": 1,
+        },
+        "attributes": {
+            "duration": 300,
+            "queue_name": QUEUE,
+            "account": ACCOUNT,
+            "custom_attributes": {"filesystems": "eagle"},
+        },
+    }
+    response = requests.post(url, json=data, headers=HEADERS)
+    return assert_status("Submit job", response, expected=200)
+
+
+def get_job_stdout_path(job_id: str) -> str:
+    return f"{OUTPUT_PATH}/{job_id}.OU"
+
+
+def view_file(path: str, size: int = 4096, offset: int = 0) -> Task:
+    url = f"{BASE_URL}/filesystem/view/{FILESYSTEM_RESOURCE_ID}"
+    response = requests.get(url, params={"path": path, "size": size, "offset": offset}, headers=HEADERS)
+    data = assert_status(f"filesystem/view {path}", response, expected=200)
+    task_id = data.get("task_id")
+    if not task_id:
+        print(f"  [FAIL] No task_id in view response: {data}")
+        sys.exit(1)
+    print(f"  [INFO] task_id = {task_id}")
+    return wait_for_task(task_id)
+
+
+def head_file(path: str, lines: int = 20) -> Task:
+    url = f"{BASE_URL}/filesystem/head/{FILESYSTEM_RESOURCE_ID}"
+    response = requests.get(url, params={"path": path, "lines": lines}, headers=HEADERS)
+    data = assert_status(f"filesystem/head {path}", response, expected=200)
+    task_id = data.get("task_id")
+    if not task_id:
+        print(f"  [FAIL] No task_id in head response: {data}")
+        sys.exit(1)
+    print(f"  [INFO] task_id = {task_id}")
+    return wait_for_task(task_id)
+
+
+# ── Test ───────────────────────────────────────────────────────────────────────
+
+def test_submit_and_read_stdout() -> bool:
+    section("TEST: Job submission + stdout file verification")
+    try:
+        submit_data = submit_job()
+        job_id = str(submit_data.get("job_id") or submit_data.get("id") or "")
+        if not job_id:
+            print(f"  [FAIL] No job_id in submit response: {submit_data}")
+            return False
+        print(f"  [INFO] Submitted job_id = {job_id}")
+
+        print("  [INFO] Waiting for job to complete...")
+        final_data = wait_for_job(COMPUTE_RESOURCE_ID, job_id)
+        final_state = extract_job_state(final_data)
+        print(f"  [INFO] Final job state: {final_state}")
+
+        if final_state in (JobState.FAILED.value, JobState.CANCELED.value):
+            print(f"  [WARN] Job ended in state {final_state}; will still attempt to read stdout.")
+
+        stdout_path = get_job_stdout_path(job_id)
+        print(f"  [INFO] Expected stdout file: {stdout_path}")
+
+        section("  Reading stdout via filesystem/head")
+        head_result = head_file(stdout_path, lines=50)
+        content = head_result.result or {}
+
+        if SENTINEL in str(content):
+            print(f"  [OK]   Sentinel string '{SENTINEL}' found in stdout.")
+            return True
+
+        section("  Fallback: reading stdout via filesystem/view")
+        view_result = view_file(stdout_path, size=8192, offset=0)
+        content = view_result.result or {}
+
+        if SENTINEL in str(content):
+            print(f"  [OK]   Sentinel string '{SENTINEL}' found in stdout via view.")
+            return True
+
+        print(f"  [FAIL] Sentinel string '{SENTINEL}' NOT found in stdout file.")
+        return False
+
+    except SystemExit:
+        return False
+
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    print("\nJob Stdout Test Suite")
+    print(f"  BASE_URL               : {BASE_URL}")
+    print(f"  COMPUTE_RESOURCE_ID    : {COMPUTE_RESOURCE_ID}")
+    print(f"  FILESYSTEM_RESOURCE_ID : {FILESYSTEM_RESOURCE_ID}")
+    print(f"  QUEUE                  : {QUEUE}")
+    print(f"  ACCOUNT                : {ACCOUNT}")
+    print(f"  OUTPUT_PATH            : {OUTPUT_PATH}")
+    print(f"  SENTINEL               : {SENTINEL}")
+
+    record("submit_and_read_stdout", test_submit_and_read_stdout())
+
+    result_summary(passed, failed)
+
+
+if __name__ == "__main__":
+    main()

--- a/alcf/tests/utils.py
+++ b/alcf/tests/utils.py
@@ -1,0 +1,189 @@
+# 
+# AI generated
+#
+
+import os
+import sys
+import time
+import json
+import logging
+import requests
+from dotenv import load_dotenv
+
+logging.disable(logging.WARNING)
+from app.routers.compute.models import JobState
+from app.routers.task.models import Task, TaskStatus
+logging.disable(logging.NOTSET)
+
+load_dotenv(override=True)
+
+
+def get_env(key: str, required: bool = True) -> str:
+    value = os.getenv(key)
+    if required and not value:
+        print(f"[ERROR] Missing required environment variable: {key}")
+        print("        Copy .env.example to .env and fill in the values.")
+        sys.exit(1)
+    return value or ""
+
+
+def get_headers() -> dict:
+    return {
+        "Authorization": f"Bearer {get_env('ACCESS_TOKEN')}",
+        "Content-Type": "application/json",
+    }
+
+
+def get_base_url() -> str:
+    return get_env("BASE_URL").rstrip("/")
+
+
+def print_response(label: str, response: requests.Response, verbose: bool = True) -> None:
+    status = response.status_code
+    ok = 200 <= status < 300
+    symbol = "OK" if ok else "FAIL"
+    print(f"  [{symbol}] {label} -> HTTP {status}")
+    if verbose:
+        try:
+            print(json.dumps(response.json(), indent=4))
+        except Exception:
+            print(response.text)
+
+
+def pretty(data: dict | list) -> str:
+    return json.dumps(data, indent=4)
+
+
+def assert_status(label: str, response: requests.Response, expected: int = 200) -> dict:
+    try:
+        body = response.json()
+    except Exception:
+        body = None
+
+    if response.status_code != expected:
+        print(f"  [FAIL] {label}: expected HTTP {expected}, got {response.status_code}")
+        print(pretty(body) if body is not None else response.text)
+        sys.exit(1)
+
+    print(f"  [OK]   {label} -> HTTP {response.status_code}")
+    if body is not None:
+        print(pretty(body))
+    return body or {}
+
+
+def wait_for_task(
+    task_id: str,
+    poll_interval: float | None = None,
+    timeout: float | None = None,
+    verbose: bool = True,
+) -> Task:
+    base_url = get_base_url()
+    headers = get_headers()
+    poll_interval = poll_interval or float(get_env("TASK_POLL_INTERVAL") or 5)
+    timeout = timeout or float(get_env("TASK_TIMEOUT") or 120)
+
+    url = f"{base_url}/task/{task_id}"
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        response = requests.get(url, headers=headers)
+        if response.status_code != 200:
+            print(f"  [WARN] Task poll HTTP {response.status_code}")
+            time.sleep(poll_interval)
+            continue
+
+        task = Task.model_validate(response.json())
+
+        if verbose:
+            print(f"  [POLL] Task {task.id} status: {task.status.value}")
+
+        if task.status == TaskStatus.completed:
+            print(pretty(task.model_dump()))
+            return task
+        if task.status == TaskStatus.failed:
+            print(f"  [FAIL] Task {task.id} ended with status: {task.status.value}")
+            print(pretty(task.model_dump()))
+            sys.exit(1)
+
+        time.sleep(poll_interval)
+
+    print(f"  [FAIL] Task {task_id} did not complete within {timeout}s")
+    sys.exit(1)
+
+
+TERMINAL_JOB_STATES = {
+    JobState.COMPLETED.value,
+    JobState.FAILED.value,
+    JobState.CANCELED.value
+}
+
+
+def extract_job_state(data: dict) -> str:
+    status_field = data.get("status") or {}
+    if isinstance(status_field, dict):
+        return (status_field.get("state") or "").lower()
+    return (status_field or data.get("state") or "").lower()
+
+
+def wait_for_job(
+    resource_id: str,
+    job_id: str,
+    terminal_states: set | None = None,
+    poll_interval: float | None = None,
+    timeout: float | None = None,
+    verbose: bool = True,
+) -> dict:
+    base_url = get_base_url()
+    headers = get_headers()
+    poll_interval = poll_interval or float(get_env("TASK_POLL_INTERVAL") or 5)
+    timeout = timeout or float(get_env("JOB_TIMEOUT") or 600)
+    if terminal_states is None:
+        terminal_states = TERMINAL_JOB_STATES
+
+    deadline = time.time() + timeout
+    attempt = 0
+
+    while time.time() < deadline:
+        attempt += 1
+
+        # After a job ends it disappears from the active queue; use historical=true
+        for historical in ("false", "true"):
+            url = f"{base_url}/compute/status/{resource_id}/{job_id}?historical={historical}"
+            response = requests.get(url, headers=headers)
+            if response.status_code == 200:
+                data = response.json()
+                state = extract_job_state(data)
+                if verbose:
+                    print(f"  [POLL] Job {job_id} state: {state}")
+                if state in terminal_states:
+                    print(pretty(data))
+                    return data
+                break
+            elif historical == "true":
+                if verbose:
+                    print(f"  [WARN] Job poll attempt {attempt}: HTTP {response.status_code}")
+
+        time.sleep(poll_interval)
+
+    print(f"  [FAIL] Job {job_id} did not reach terminal state within {timeout}s")
+    sys.exit(1)
+
+
+def section(title: str) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print("=" * 60)
+
+
+def result_summary(passed: list[str], failed: list[str]) -> None:
+    print(f"\n{'=' * 60}")
+    print("  TEST SUMMARY")
+    print("=" * 60)
+    for name in passed:
+        print(f"  [PASS] {name}")
+    for name in failed:
+        print(f"  [FAIL] {name}")
+    total = len(passed) + len(failed)
+    print(f"\n  {len(passed)}/{total} tests passed")
+    if failed:
+        sys.exit(1)


### PR DESCRIPTION
- Adding `rm` command to Filesystem (already approved for first deployment, it was just missing in production)
- Adding test scripts to run real-case examples to test our API routes. It is not an automated pipeline since this must run with a freshly-generated user token, targeting real filesystem locations.