### PR TITLE
added safety feature in case optional fields are None

### DIFF
--- a/alcf/account/models.py
+++ b/alcf/account/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from pydantic import BaseModel, field_validator, Field, model_validator
+from pydantic import BaseModel, field_validator, Field
 from typing import List, Optional
 
 from app.routers.account.models import AllocationUnit

--- a/alcf/account/models.py
+++ b/alcf/account/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from pydantic import BaseModel, field_validator, Field
+from pydantic import BaseModel, field_validator, Field, model_validator
 from typing import List, Optional
 
 from app.routers.account.models import AllocationUnit
@@ -12,6 +12,16 @@ class NiProject(BaseModel):
     resources: List[str]
     description: Optional[str] = Field(default="N/A")
     last_modified: Optional[datetime] = Field(default=datetime(2000, 1, 1, 0, 0, 0, tzinfo=timezone.utc))
+
+    @field_validator("description", "last_modified", mode="before")
+    @classmethod
+    def default_none_fields(cls, v, info):
+        if v is None:
+            if info.field_name == "last_modified":
+                return datetime(2000, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+            if info.field_name == "description":
+                return "N/A"
+        return v
 
 
 class NiAllocation(BaseModel):
@@ -51,6 +61,16 @@ class NiCapability(BaseModel):
     charge_factor: Optional[float] = Field(default=None)
     view_factor: Optional[float] = Field(default=None)
     charge_item: Optional[str] = Field(default=None)
+
+    @field_validator("description", "last_updated", mode="before")
+    @classmethod
+    def default_none_fields(cls, v, info):
+        if v is None:
+            if info.field_name == "last_updated":
+                return datetime(2000, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+            if info.field_name == "description":
+                return "N/A"
+        return v
 
     @field_validator("units", mode="after")
     @classmethod


### PR DESCRIPTION
For some optional fields, we have a default value. But if the Ni backend explicitly provides the field but with a None value, but code crashed because the IRI spec does not accept None. We now have a pydantic validator layer that sets default values.